### PR TITLE
validate acl init

### DIFF
--- a/src/http2socks.rs
+++ b/src/http2socks.rs
@@ -23,7 +23,13 @@ where
         config
             .acl_file
             .as_ref()
-            .and_then(|acl_file| crate::acl::AccessControl::load_from_file(acl_file).ok())
+            .and_then(|acl_file| match crate::acl::AccessControl::load_from_file(acl_file) {
+                Ok(ac) => Some(ac),
+                Err(e) => {
+                    log::warn!("Could not init ACL: {e}");
+                    None
+                }
+            })
     });
 
     let listen_addr = config.listen_proxy_role.addr;

--- a/src/socks2socks.rs
+++ b/src/socks2socks.rs
@@ -23,7 +23,13 @@ where
         config
             .acl_file
             .as_ref()
-            .and_then(|acl_file| crate::acl::AccessControl::load_from_file(acl_file).ok())
+            .and_then(|acl_file| match crate::acl::AccessControl::load_from_file(acl_file) {
+                Ok(ac) => Some(ac),
+                Err(e) => {
+                    log::warn!("Could not init ACL: {e}");
+                    None
+                }
+            })
     });
 
     let listen_addr = config.listen_proxy_role.addr;


### PR DESCRIPTION
With `--acl-file`, the user isn't informed that the ACL failed to parse.